### PR TITLE
Removed long lines on output + minor fix

### DIFF
--- a/kconfig-hardened-check.py
+++ b/kconfig-hardened-check.py
@@ -206,18 +206,22 @@ def construct_checklist():
 
 def print_checklist():
     print('[+] Printing kernel hardening preferences...')
-    print('  {:<39}|{:^13}|{:^10}|{:^20}'.format('option name', 'desired val', 'decision', 'reason'))
-    print('  ======================================================================================')
+    print('  {:<39}|{:^13}|{:^10}|{:^20}'.format(
+        'option name', 'desired val', 'decision', 'reason'))
+    print('  ' + '=' * 88)
     for opt in checklist:
-        print('  CONFIG_{:<32}|{:^13}|{:^10}|{:^20}'.format(opt.name, opt.expected, opt.decision, opt.reason))
+        print('  CONFIG_{:<32}|{:^13}|{:^10}|{:^20}'.format(
+                opt.name, opt.expected, opt.decision, opt.reason))
     print()
 
 
 def print_check_results():
-    print('  {:<39}|{:^13}|{:^10}|{:^20}||{:^28}'.format('option name', 'desired val', 'decision', 'reason', 'check result'))
-    print('  ===================================================================================================================')
+    print('  {:<39}|{:^13}|{:^10}|{:^20}||{:^28}'.format(
+        'option name', 'desired val', 'decision', 'reason', 'check result'))
+    print('  ' + '=' * 115)
     for opt in checklist:
-        print('  CONFIG_{:<32}|{:^13}|{:^10}|{:^20}||{:^28}'.format(opt.name, opt.expected, opt.decision, opt.reason, opt.result))
+        print('  CONFIG_{:<32}|{:^13}|{:^10}|{:^20}||{:^28}'.format(
+            opt.name, opt.expected, opt.decision, opt.reason, opt.result))
     print()
 
 

--- a/kconfig-hardened-check.py
+++ b/kconfig-hardened-check.py
@@ -226,7 +226,7 @@ def print_check_results():
 
 
 def get_option_state(options, name):
-    return options[name] if name in options else None
+    return options.get(name, None)
 
 
 def perform_checks(parsed_options):


### PR DESCRIPTION
I removed long lines from `print` and `format` functions.
Also i edited function `get_option_state` now uses `dict.get` method to extract a key from dict with default value 