### PR TITLE
Teach the script about target architecture and kernel version

### DIFF
--- a/config_files/kspp-recommendations.config
+++ b/config_files/kspp-recommendations.config
@@ -1,4 +1,5 @@
 # CONFIGs
+# Linux/x86_64 4.20 Kernel Configuration
 
 # Report BUG() conditions and kill the offending process.
 CONFIG_BUG=y
@@ -10,8 +11,8 @@ CONFIG_STRICT_KERNEL_RWX=y
 CONFIG_DEBUG_WX=y
 
 # Use -fstack-protector-strong (gcc 4.9+) for best stack canary coverage.
-CONFIG_CC_STACKPROTECTOR=y
-CONFIG_CC_STACKPROTECTOR_STRONG=y
+CONFIG_STACKPROTECTOR=y
+CONFIG_STACKPROTECTOR_STRONG=y
 
 # Do not allow direct physical memory access (but if you must have it, at least enable STRICT mode...)
 # CONFIG_DEVMEM is not set

--- a/kconfig-hardened-check.py
+++ b/kconfig-hardened-check.py
@@ -34,6 +34,9 @@ from argparse import ArgumentParser
 from collections import OrderedDict
 import re
 
+X86_64 = "x86_64"
+SUPPORTED_ARCHS = [ X86_64 ]
+
 debug_mode = False  # set it to True to print the unknown options from the config
 checklist = []
 
@@ -338,6 +341,9 @@ if __name__ == '__main__':
             if not kernel_version:
                 sys.exit('[!] ERROR: failed to auto-detect kernel version from kconfig')
             args.kernel_version = kernel_version
+
+    if args.arch not in SUPPORTED_ARCHS:
+        print('[!] WARNING: %s is not a supported architecture' % args.arch, file=sys.stderr)
 
     construct_checklist()
 


### PR DESCRIPTION
Some recommendations are dependent on the processor architecture and/or the kernel version. For example, the KSPP recommendations differ between [x86_32](https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings#x86_32) and [x86_64](https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings#x86_64). Additionally, option names change over time such as when `CONFIG_CC_STACKPROTECTOR_STRONG` was [renamed](https://kernsec.org/wiki/index.php?title=Kernel_Self_Protection_Project%2FRecommended_Settings&diff=3983&oldid=3976).

This pull request adds the ability to reason about the architecture and version when constructing the checklist. It also teaches the script about `x86_32`, `arm`, and `arm64` specific config recommendations.