### PR TITLE
Recommend PANIC_ON_OOPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ CONFIG_RESET_ATTACK_MITIGATION               |      y      |    my    |  self_pr
 CONFIG_PAGE_POISONING_NO_SANITY              | is not set  |    my    |  self_protection   |   FAIL: CONFIG_PAGE_POISONING is needed
 CONFIG_PAGE_POISONING_ZERO                   | is not set  |    my    |  self_protection   |   FAIL: CONFIG_PAGE_POISONING is needed
 CONFIG_AMD_IOMMU_V2                          |      y      |    my    |  self_protection   |   FAIL: "m"
+CONFIG_PANIC_ON_OOPS                         |      y      |    kspp  |  self_protection   |   FAIL: "is not set"
 CONFIG_SECURITY                              |      y      |defconfig |  security_policy   |   OK
 CONFIG_SECURITY_WRITABLE_HOOKS               | is not set  |defconfig |  security_policy   |   OK
 CONFIG_SECURITY_YAMA                         |      y      |   kspp   |  security_policy   |   OK
@@ -181,7 +182,7 @@ CONFIG_BPF_JIT                               | is not set  |    my    | cut_atta
 CONFIG_VIDEO_VIVID                           | is not set  |    my    | cut_attack_surface |   FAIL: "m"
 CONFIG_ARCH_MMAP_RND_BITS                    |     32      |  clipos  |userspace_hardening |   FAIL: "28"
 
-[+] config check is finished: 'OK' - 49 / 'FAIL' - 77
+[+] config check is finished: 'OK' - 49 / 'FAIL' - 78
 ```
 
 ## kconfig-hardened-check versioning

--- a/kconfig-hardened-check.py
+++ b/kconfig-hardened-check.py
@@ -296,6 +296,7 @@ def construct_checklist(checklist, arch):
         checklist.append(OptCheck('PAGE_TABLE_ISOLATION',               'y', 'my', 'self_protection'))
     if debug_mode or arch == 'ARM':
         checklist.append(OptCheck('STACKPROTECTOR_PER_TASK',            'y', 'my', 'self_protection'))
+    checklist.append(OptCheck('PANIC_ON_OOPS',                         'y', 'kspp', 'self_protection'))
 
     if debug_mode or arch == 'X86_64' or arch == 'ARM64' or arch == 'X86_32':
         checklist.append(OptCheck('SECURITY',                               'y', 'defconfig', 'security_policy')) # and choose your favourite LSM


### PR DESCRIPTION
This causes the kernel to panic on an oops.

Recommended by the KSPP and CLIP OS.

https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings

> \# Reboot devices immediately if kernel experiences an Oops.
> CONFIG_PANIC_ON_OOPS=y
> CONFIG_PANIC_TIMEOUT=-1

https://docs.clip-os.org/clipos/kernel.html

> CONFIG_PANIC_ON_OOPS=y
> CONFIG_PANIC_TIMEOUT=-1
>
>    Prevent potential further exploitation of a bug by immediately panicking the kernel.