### PR TITLE
Add RANDOMIZE_KSTACK_OFFSET_DEFAULT

### DIFF
--- a/kconfig_hardened_check/__init__.py
+++ b/kconfig_hardened_check/__init__.py
@@ -380,6 +380,8 @@ def construct_checklist(l, arch):
     if arch in ('X86_64', 'ARM64', 'X86_32'):
         stackleak_is_set = OptCheck('self_protection', 'kspp', 'GCC_PLUGIN_STACKLEAK', 'y')
         l += [stackleak_is_set]
+        l += [OR(OptCheck('self_protection', 'kspp', 'RANDOMIZE_KSTACK_OFFSET_DEFAULT', 'y'),
+                 VerCheck((5, 13)))]  # RANDOMIZE_KSTACK_OFFSET_DEFAULT was added in v5.13
     if arch in ('X86_64', 'X86_32'):
         l += [OptCheck('self_protection', 'kspp', 'DEFAULT_MMAP_MIN_ADDR', '65536')]
     if arch in ('ARM64', 'ARM'):


### PR DESCRIPTION
Randomize kernel stack offset on syscall entry

The kernel stack offset can be randomized (after pt_regs) by
roughly 5 bits of entropy, frustrating memory corruption
attacks that depend on stack address determinism or
cross-syscall address exposures. This feature is controlled
by kernel boot param "randomize_kstack_offset=on/off", and this
config chooses the default boot state.