### PR TITLE
Add BLK_DEV_FD

### DIFF
--- a/kconfig_hardened_check/__init__.py
+++ b/kconfig_hardened_check/__init__.py
@@ -510,6 +510,7 @@ def construct_checklist(l, arch):
     l += [OptCheck('cut_attack_surface', 'maintainer', 'DRM_LEGACY', 'is not set')]
     l += [OptCheck('cut_attack_surface', 'maintainer', 'FB', 'is not set')]
     l += [OptCheck('cut_attack_surface', 'maintainer', 'VT', 'is not set')]
+    l += [OptCheck('cut_attack_surface', 'maintainer', 'BLK_DEV_FD', 'is not set')]
 
     # 'cut_attack_surface', 'grapheneos'
     l += [OptCheck('cut_attack_surface', 'grapheneos', 'AIO', 'is not set')]


### PR DESCRIPTION
Floppy driver was written many years ago. It was designed to
work in a single-threaded environment (many global variables)
and to work on real hardware which has significant delays
(floppy drives are slow). Nowadays, when we use virtual
devices (which are fast) and multi-core cpus, floppy driver
shows its problems including deadlocking/livelocking and
other security-related issues. However, we can't just
rewrite it because lack of real hardware and compatibility
with existing userspace tools, many of which rely on
undocumented driver behavior.

Here are some CVEs related to floppy driver:
 - CVE-2014-1737 privileges escalation in FDRAWCMD ioctl
 - CVE-2014-1738 info leak from kernel heap in FDRAWCMD ioctl
 - CVE-2018-7755 kernel pointer lead in FDGETPRM ioctl
 - CVE-2019-14283 integer overflow and out-of-bounds read in set_geometry
 - CVE-2019-14284 denial of service in setup_format_params
 - CVE-2020-9383 out-of-bounds read in set_fdc
 - CVE-2021-20261 race condition in floppy_revalidate,
   floppy_check_events

As pointed by Linus [1]:
> The only users are virtualization, and even they are going away
> because floppies are so small, and other things have become more
> standard anyway (ie USB disk) or easier to emulate (NVMe or whatever).
> So I suspect the only reason floppy is used even in that area is just
> legacy "we haven't bothered updating to anything better and we have
> old scripts and images that work".

CONFIG_BLK_DEV_FD is not enabled in defconfig on x86_64.
Many distros already require root access for /dev/fd0.
However, qemu (5.2.0) still enables floppy device by default.

[1] https://lore.kernel.org/all/CAHk-=whFAAV_TOLFNnj=wu4mD2L9OvgB6n2sKDdmd8buMKFv8A@mail.gmail.com/