### PR TITLE
Add disabling compatibility mode.

### DIFF
--- a/kconfig_hardened_check/__init__.py
+++ b/kconfig_hardened_check/__init__.py
@@ -660,6 +660,13 @@ def add_kconfig_checks(l, arch):
     l += [KconfigCheck('cut_attack_surface', 'my', 'VIDEO_VIVID', 'is not set')]
     l += [KconfigCheck('cut_attack_surface', 'my', 'INPUT_EVBUG', 'is not set')] # Can be used as a keylogger
     l += [KconfigCheck('cut_attack_surface', 'my', 'KGDB', 'is not set')]
+    
+    # 'cut_attack_surface', 'manouchehri'
+    if arch in ('X86_64', 'ARM64'):
+        l += [KconfigCheck('cut_attack_surface', 'manouchehri', 'COMPAT', 'is not set')] 
+        # ASLR on 32-bit is broken by design.
+        # Mitigates multiple CVEs (historically) that are only reachable through compatibility mode.
+        # Reduces the odds of shooting yourself in the foot with things like seccomp being different.
 
     # 'harden_userspace'
     if arch in ('X86_64', 'ARM64', 'X86_32'):


### PR DESCRIPTION
I'm not a kernel maintainer, so I added myself a new category. I don't think I'm wrong about this one though, here's a few public examples I found within a minute of searching:

https://google.github.io/security-research/pocs/linux/cve-2021-22555/writeup.html
https://bugs.chromium.org/p/project-zero/issues/detail?id=1574
https://outflux.net/blog/archives/2010/10/19/cve-2010-2963-v4l-compat-exploit/
http://inertiawar.com/compat1/
http://inertiawar.com/compat2/